### PR TITLE
Add Mailpoet for newsletter-y stuff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "wpackagist-plugin/akismet": "*",
         "wpackagist-plugin/autoblue": "*",
         "wpackagist-plugin/imagify": "^2.2",
+        "wpackagist-plugin/mailpoet": "^5.12",
         "wpackagist-plugin/ninja-forms": "*",
         "wpackagist-plugin/pantheon-advanced-page-cache": "*",
         "wpackagist-plugin/powerpress": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f529691b4099261693368911e2213f5d",
+    "content-hash": "1d5bda677165e42e44b440568787eae1",
     "packages": [
         {
             "name": "composer/installers",
@@ -1321,6 +1321,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/imagify/"
+        },
+        {
+            "name": "wpackagist-plugin/mailpoet",
+            "version": "5.12.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/mailpoet/",
+                "reference": "tags/5.12.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/mailpoet.5.12.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/mailpoet/"
         },
         {
             "name": "wpackagist-plugin/ninja-forms",


### PR DESCRIPTION
The podcast should do email marketing of some kind because email is sticky. Being notified of episodes (and maybe blog posts that talk about the latest/upcoming episode with a link to it) is a good way to get more human content out and potentially engagement.

Look at me using words like "engagement".