### PR TITLE
Fix og: tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ Thumbs.db
 # SASS #
 ##########
 .sass-cache
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md
+.codacy

--- a/config/application.php
+++ b/config/application.php
@@ -36,7 +36,8 @@ function _cc_filter_nr_script_for_bots() {
 	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
 		newrelic_disable_autorum();
 	} else {
-        echo "\n<!-- NR diag: newrelic_disable_autorum function exists?" . function_exists( 'newrelic_disable_autorum' ) . "; bot? " . $is_unfurl_bot . " -->\n";
+        echo "\n<!-- NR diag: newrelic_disable_autorum function exists?" . function_exists( 'newrelic_disable_autorum' ) . " -->\n";
+        echo "<!-- NR diag: bot? " . $is_unfurl_bot . " -->\n";
     }
 }
 _cc_filter_nr_script_for_bots();

--- a/config/application.php
+++ b/config/application.php
@@ -35,10 +35,7 @@ function _cc_filter_nr_script_for_bots() {
 	// Disable New Relic agent.
 	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
 		newrelic_disable_autorum();
-	} else {
-        echo "\n<!-- NR diag: newrelic_disable_autorum function exists?" . function_exists( 'newrelic_disable_autorum' ) . " -->\n";
-        echo "<!-- NR diag: bot? " . $is_unfurl_bot . " -->\n";
-    }
+	}
 }
 _cc_filter_nr_script_for_bots();
 

--- a/config/application.php
+++ b/config/application.php
@@ -27,13 +27,17 @@ $root_dir = dirname( __DIR__ );
  */
 $webroot_dir = $root_dir . '/web';
 
-/**
- * Disable New Relic agent.
- * Re-add it later in the execution.
- */
-if ( function_exists( 'newrelic_disable_autorum' ) ) {
-    newrelic_disable_autorum();
+function _cc_filter_nr_script_for_bots() {
+
+	$ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+	$is_unfurl_bot = preg_match( '/Slackbot-LinkExpanding|Slackbot|Discordbot|LinkedInBot|Twitterbot|facebookexternalhit|SkypeUriPreview/i', $ua );
+
+	// Disable New Relic agent.
+	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
+		newrelic_disable_autorum();
+	}
 }
+_cc_filter_nr_script_for_bots();
 
 /**
  * Use Dotenv to set required environment variables and load .env file in root

--- a/config/application.php
+++ b/config/application.php
@@ -28,6 +28,14 @@ $root_dir = dirname( __DIR__ );
 $webroot_dir = $root_dir . '/web';
 
 /**
+ * Disable New Relic agent.
+ * Re-add it later in the execution.
+ */
+if ( function_exists( 'newrelic_disable_autorum' ) ) {
+    newrelic_disable_autorum();
+}
+
+/**
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */

--- a/config/application.php
+++ b/config/application.php
@@ -36,7 +36,7 @@ function _cc_filter_nr_script_for_bots() {
 	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
 		newrelic_disable_autorum();
 	} else {
-        echo "\n<!-- NR diag: not a bot or no newrelic_disable_autorum function -->\n";
+        echo "\n<!-- NR diag: newrelic_disable_autorum function exists?" . function_exists( 'newrelic_disable_autorum' ) . "; bot? " . $is_unfurl_bot . " -->\n";
     }
 }
 _cc_filter_nr_script_for_bots();

--- a/config/application.php
+++ b/config/application.php
@@ -33,8 +33,15 @@ function _cc_filter_nr_script_for_bots() {
 	$is_unfurl_bot = preg_match( '/Slackbot-LinkExpanding|Slackbot|Discordbot|LinkedInBot|Twitterbot|facebookexternalhit|SkypeUriPreview/i', $ua );
 
 	// Disable New Relic agent.
-	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
-		newrelic_disable_autorum();
+	if ( $is_unfurl_bot ) {
+        if ( function_exists( 'newrelic_disable_autorum' ) ) {
+		    newrelic_disable_autorum();
+        }
+
+        if ( ! headers_sent() ) {
+            header( 'Vary: User-Agent' );
+            header( 'Cache-Control: private, no-store' );
+        }
 	}
 }
 _cc_filter_nr_script_for_bots();

--- a/config/application.php
+++ b/config/application.php
@@ -35,7 +35,9 @@ function _cc_filter_nr_script_for_bots() {
 	// Disable New Relic agent.
 	if ( function_exists( 'newrelic_disable_autorum' ) && $is_unfurl_bot ) {
 		newrelic_disable_autorum();
-	}
+	} else {
+        echo "\n<!-- NR diag: not a bot or no newrelic_disable_autorum function -->\n";
+    }
 }
 _cc_filter_nr_script_for_bots();
 

--- a/config/application.php
+++ b/config/application.php
@@ -30,10 +30,19 @@ $webroot_dir = $root_dir . '/web';
 function _cc_filter_nr_script_for_bots() {
 
 	$ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+    $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
+    $uri = $_SERVER['REQUEST_URI'] ?? '';
+    $method = $_SERVER['REQUEST_METHOD'] ?? '';
+    $is_html_request = (stripos( $accept, 'text/html' ) !== false) && ($method === 'GET');
+    $is_adminish = (strpos($uri, '/wp-admin/') !== false) || (strpos($uri, '/wp-login.php') !== false);
+    $is_rest = (strpos($uri, '/wp-json/') !== false);
+    $is_feed = (strpos($uri, '/feed') !== false);
+    $is_robots = (strpos($uri, '/robots.txt') !== false);
+    $is_front = $is_html_request && ! $is_adminish && ! $is_rest && ! $is_feed && ! $is_robots;
 	$is_unfurl_bot = preg_match( '/Slackbot-LinkExpanding|Slackbot|Discordbot|LinkedInBot|Twitterbot|facebookexternalhit|SkypeUriPreview/i', $ua );
 
 	// Disable New Relic agent.
-	if ( $is_unfurl_bot ) {
+	if ( $is_front && $is_unfurl_bot ) {
         if ( function_exists( 'newrelic_disable_autorum' ) ) {
 		    newrelic_disable_autorum();
         }
@@ -42,7 +51,11 @@ function _cc_filter_nr_script_for_bots() {
             header( 'Vary: User-Agent' );
             header( 'Cache-Control: private, no-store' );
         }
-	}
+	} else {
+        if ( function_exists( 'newrelic_enable_autorum' ) ) {
+            newrelic_enable_autorum();
+        }
+    }
 }
 _cc_filter_nr_script_for_bots();
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -26,9 +26,10 @@ function add_newrelic_headers() {
 	// Debug.
 	echo "\n<!-- NR diag: ext=" . (int)extension_loaded('newrelic') . " fn=" . (int)function_exists('newrelic_get_browser_timing_header') . " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
-		$raw = newrelic_get_browser_timing_header(false);
+		$raw = newrelic_get_browser_timing_header();
 		echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
-        wp_print_inline_script_tag( $raw, [ 'id' => 'newrelic-browser' ] );
+		$script_content = preg_replace('/<script[^>]*>|<\/script>/i', '', $raw);
+        wp_print_inline_script_tag( $script_content, [ 'id' => 'newrelic-browser-header' ] );
 	}
 }
 
@@ -37,9 +38,10 @@ function add_newrelic_headers() {
  */
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
-		$raw = newrelic_get_browser_timing_footer(false);
+		$raw = newrelic_get_browser_timing_footer();
 		echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
-        wp_print_inline_script_tag( $raw, [ 'id' => 'newrelic-browser' ] );
+		$script_content = preg_replace('/<script[^>]*>|<\/script>/i', '', $raw);
+        wp_print_inline_script_tag( $script_content, [ 'id' => 'newrelic-browser-footer' ] );
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -15,26 +15,26 @@ namespace CommunityCode\NewRelic;
  * Kick everything off.
  */
 function bootstrap() {
-    add_action( 'wp_head', __NAMESPACE__ . '\\add_newrelic_headers', 99 );
-    add_action( 'wp_footer', __NAMESPACE__ . '\\add_newrelic_footer', 99 );
+	add_action( 'wp_head', __NAMESPACE__ . '\\add_newrelic_headers', 99 );
+	add_action( 'wp_footer', __NAMESPACE__ . '\\add_newrelic_footer', 99 );
 }
 
 /**
  * Add New Relic headers to the page head.
  */
 function add_newrelic_headers() {
-    if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
-        echo newrelic_get_browser_timing_header();
-    }
+	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
+		echo newrelic_get_browser_timing_header();
+	}
 }
 
 /**
  * Add New Relic footer to the page footer.
  */
 function add_newrelic_footer() {
-    if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
-        echo newrelic_get_browser_timing_footer();
-    }
+	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
+		echo newrelic_get_browser_timing_footer();
+	}
 }
 
 // Bootstrap the plugin.

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -30,6 +30,7 @@ function get_newrelic_inline( string $where ) : void {
 	echo "\n<!-- NR diag {$where} length: ".strlen($raw)." -->\n";
 	if ( $raw && preg_match( '#<script\b[^>]*>([\s\S]*?)</script>#i', $raw, $m ) ) {
 		$js = $m[1];
+		echo "\n<!-- NR {$where} script stripped js length: ".strlen($js)." -->\n";
 	}
 
 	echo "\n<!-- NR diag {$where} js length: ".(empty($js) ? 0 : strlen($js))." -->\n";

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -26,14 +26,9 @@ function add_newrelic_headers() {
 	// Debug.
 	echo "\n<!-- NR diag: ext=" . (int)extension_loaded('newrelic') . " fn=" . (int)function_exists('newrelic_get_browser_timing_header') . " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
-		$raw = newrelic_get_browser_timing_header(true);
+		$raw = newrelic_get_browser_timing_header(false);
 		echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
-		if ( preg_match( '<script[^>]*>(.*?)</script>#i', $raw, $m ) ) {
-			$js = $m[1];
-			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
-		} else {
-			echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
+        wp_print_inline_script_tag( $raw, [ 'id' => 'newrelic-browser' ] );
 	}
 }
 
@@ -42,14 +37,9 @@ function add_newrelic_headers() {
  */
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
-		$raw = newrelic_get_browser_timing_footer(true);
+		$raw = newrelic_get_browser_timing_footer(false);
 		echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
-		if ( preg_match( '<script[^>]*>(.*?)</script>#i', $raw, $m ) ) {
-			$js = $m[1];
-			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
-		} else {
-			echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
+        wp_print_inline_script_tag( $raw, [ 'id' => 'newrelic-browser' ] );
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -32,6 +32,7 @@ function get_newrelic_inline( string $where ) : void {
 		$js = $m[1];
 	}
 
+	echo "\n<!-- NR diag {$where} js length: ".(empty($js) ? 0 : strlen($js))." -->\n";
 	if ( ! empty( $js ) ) {
 		wp_print_inline_script_tag( $js, [ 'id' => "newrelic-browser-{$where}" ] );
 	}

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: New Relic integration
+ * Author: Chris Reynolds
+ * License: MIT License
+ * Description: Modifies the New Relic integration to be more compatible with OpenGraph.
+ * Plugin URI: https://communitycode.dev
+ * Author URI: https://chrisreynolds.io
+ * Version: 0.1
+ */
+
+namespace CommunityCode\NewRelic;
+
+/**
+ * Kick everything off.
+ */
+function bootstrap() {
+    add_action( 'wp_head', __NAMESPACE__ . '\\add_newrelic_headers', 99 );
+    add_action( 'wp_footer', __NAMESPACE__ . '\\add_newrelic_footer', 99 );
+}
+
+/**
+ * Add New Relic headers to the page head.
+ */
+function add_newrelic_headers() {
+    if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
+        echo newrelic_get_browser_timing_header();
+    }
+}
+
+/**
+ * Add New Relic footer to the page footer.
+ */
+function add_newrelic_footer() {
+    if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
+        echo newrelic_get_browser_timing_footer();
+    }
+}
+
+// Bootstrap the plugin.
+bootstrap();

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -26,9 +26,9 @@ function add_newrelic_headers() {
 	// Debug.
 	echo "\n<!-- NR diag: ext=" . (int)extension_loaded('newrelic') . " fn=" . (int)function_exists('newrelic_get_browser_timing_header') . " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
-		$raw = newrelic_get_browser_timing_header();
+		$raw = newrelic_get_browser_timing_header(true);
 		echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
-		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+		if ( preg_match( '<script[^>]*>(.*?)</script>#i', $raw, $m ) ) {
 			$js = $m[1];
 			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
 		} else {
@@ -42,9 +42,9 @@ function add_newrelic_headers() {
  */
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
-		$raw = newrelic_get_browser_timing_footer();
+		$raw = newrelic_get_browser_timing_footer(true);
 		echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
-		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+		if ( preg_match( '<script[^>]*>(.*?)</script>#i', $raw, $m ) ) {
 			$js = $m[1];
 			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
 		} else {

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -27,7 +27,7 @@ function get_newrelic_inline( string $where ) : void {
 		return;
 	}
 
-	$raw = $fn();
+	$raw = $fn(true);
 	echo "\n<!-- NR diag {$where} length: ".strlen($raw)." -->\n";
 	if ( $raw && preg_match( '#<script\b[^>]*>([\s\S]*?)</script>#i', $raw, $m ) ) {
 		$js = $m[1];

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -23,21 +23,32 @@ function get_newrelic_inline( string $where ) : void {
 	$fn = $where === 'footer' ? 'newrelic_get_browser_timing_footer' : 'newrelic_get_browser_timing_header';
 
 	if ( ! function_exists( $fn ) ) {
-        echo "\n<!-- NR diag {$where} function {$fn} does not exist -->\n";
+		echo "\n<!-- NR diag {$where} function {$fn} does not exist -->\n";
 		return;
 	}
 
-	$raw = $fn(true);
-	echo "\n<!-- NR diag {$where} length: ".strlen($raw)." -->\n";
-	if ( $raw && preg_match( '#<script\b[^>]*>([\s\S]*?)</script>#i', $raw, $m ) ) {
-		$js = $m[1];
-		echo "\n<!-- NR {$where} script stripped js length: ".strlen($js)." -->\n";
+	// 1) Try JS-only (no <script> wrapper).
+	$js_only = $fn( false );
+	echo "\n<!-- NR diag {$where}: js_only len " . strlen( (string) $js_only ) . " -->\n";
+
+	if ( $js_only !== '' ) {
+		// Print inside a proper <script> tag (no raw JS echo).
+		wp_print_inline_script_tag( $js_only, [ 'id' => "newrelic-browser-$where" ] );
+		return;
 	}
 
-	echo "\n<!-- NR diag {$where} js length: ".(empty($js) ? 0 : strlen($js))." -->\n";
-	if ( ! empty( $js ) ) {
-		echo $js;
+	// 2) Fallback: try wrapped (<script>…</script>) and emit it as-is so it executes.
+	$wrapped = $fn( true );
+	echo "\n<!-- NR diag {$where}: wrapped len " . strlen( (string) $wrapped ) . " -->\n";
+
+	if ( $wrapped !== '' ) {
+		// DO NOT strip the tag here; print the full tag so the code actually runs.
+		echo $wrapped; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return;
 	}
+
+	// 3) Nothing available.
+	echo "\n<!-- NR diag {$where}: no snippet returned -->\n";
 }
 
 /**

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -23,11 +23,11 @@ function bootstrap() {
  * Add New Relic headers to the page head.
  */
 function add_newrelic_headers() {
-    // Debug.
+	// Debug.
 	echo "\n<!-- NR diag: ext=" . (int)extension_loaded('newrelic') . " fn=" . (int)function_exists('newrelic_get_browser_timing_header') . " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
 		$raw = newrelic_get_browser_timing_header();
-        echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
+		echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
 		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
 			$js = $m[1];
 			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
@@ -43,7 +43,7 @@ function add_newrelic_headers() {
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
 		$raw = newrelic_get_browser_timing_footer();
-        echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
+		echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
 		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
 			$js = $m[1];
 			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -35,7 +35,14 @@ function get_newrelic_inline( string $where ) : void {
 
 	echo "\n<!-- NR diag {$where} js length: ".(empty($js) ? 0 : strlen($js))." -->\n";
 	if ( ! empty( $js ) ) {
-		wp_print_inline_script_tag( $js, [ 'id' => "newrelic-browser-{$where}" ] );
+		echo wp_kses( $js, [
+			'script' => [
+				'type' => true,
+				'src' => true,
+				'async' => true,
+				'defer' => true,
+			],
+		] );
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -19,6 +19,11 @@ function bootstrap() {
 	add_action( 'wp_footer', __NAMESPACE__ . '\\add_newrelic_footer', 99 );
 }
 
+/**
+ * Get New Relic inline script for header or footer.
+ *
+ * @param string $where 'header' or 'footer'.
+ */
 function get_newrelic_inline( string $where ) : void {
 	$fn = $where === 'footer' ? 'newrelic_get_browser_timing_footer' : 'newrelic_get_browser_timing_header';
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -24,11 +24,7 @@ function bootstrap() {
  */
 function add_newrelic_headers() {
     // Debug.
-	echo "\n<!-- NR diag: ext=";
-    echo (int)extension_loaded('newrelic');
-    echo " fn=";
-    echo (int)function_exists('newrelic_get_browser_timing_header');
-    echo " -->\n";
+	echo "\n<!-- NR diag: ext=" . (int)extension_loaded('newrelic') . " fn=" . (int)function_exists('newrelic_get_browser_timing_header') . " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
 		$raw = newrelic_get_browser_timing_header();
         echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -35,14 +35,7 @@ function get_newrelic_inline( string $where ) : void {
 
 	echo "\n<!-- NR diag {$where} js length: ".(empty($js) ? 0 : strlen($js))." -->\n";
 	if ( ! empty( $js ) ) {
-		echo wp_kses( $js, [
-			'script' => [
-				'type' => true,
-				'src' => true,
-				'async' => true,
-				'defer' => true,
-			],
-		] );
+		echo $js;
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -23,14 +23,21 @@ function bootstrap() {
  * Add New Relic headers to the page head.
  */
 function add_newrelic_headers() {
+    // Debug.
+	echo "\n<!-- NR diag: ext=";
+    echo (int)extension_loaded('newrelic');
+    echo " fn=";
+    echo (int)function_exists('newrelic_get_browser_timing_header');
+    echo " -->\n";
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
 		$raw = newrelic_get_browser_timing_header();
-        if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
-            $js = $m[1];
-            wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
-        } else {
-            echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
+        echo "\n<!-- NR diag header length: ".strlen($raw)." -->\n";
+		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+			$js = $m[1];
+			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
+		} else {
+			echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 	}
 }
 
@@ -40,12 +47,13 @@ function add_newrelic_headers() {
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
 		$raw = newrelic_get_browser_timing_footer();
-        if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
-            $js = $m[1];
-            wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
-        } else {
-            echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
+        echo "\n<!-- NR diag footer length: ".strlen($raw)." -->\n";
+		if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+			$js = $m[1];
+			wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
+		} else {
+			echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -84,4 +84,4 @@ function add_newrelic_footer() {
 }
 
 // Bootstrap the plugin.
-bootstrap();
+// bootstrap();

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -24,7 +24,13 @@ function bootstrap() {
  */
 function add_newrelic_headers() {
 	if ( function_exists( 'newrelic_get_browser_timing_header' ) ) {
-		echo newrelic_get_browser_timing_header();
+		$raw = newrelic_get_browser_timing_header();
+        if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+            $js = $m[1];
+            wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
+        } else {
+            echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
 	}
 }
 
@@ -33,7 +39,13 @@ function add_newrelic_headers() {
  */
 function add_newrelic_footer() {
 	if ( function_exists( 'newrelic_get_browser_timing_footer' ) ) {
-		echo newrelic_get_browser_timing_footer();
+		$raw = newrelic_get_browser_timing_footer();
+        if ( preg_match( '#<script|^>]*>(.*)</script>#is', $raw, $m ) ) {
+            $js = $m[1];
+            wp_print_inline_script_tag( $js, [ 'id' => 'newrelic-browser' ] );
+        } else {
+            echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
 	}
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -47,7 +47,20 @@ function get_newrelic_inline( string $where ) : void {
 		return;
 	}
 
-	// 3) Nothing available.
+    // 3) Last attempt. Try with no parameter. In the past this has printed the raw javascript.
+    $raw = $fn();
+    echo "\n<!-- NR diag {$where}: raw len " . strlen( (string) $raw ) . " -->\n";
+    if ( $raw !== '' ) {
+        // Check if the script has a <script> tag. If not, wrap it.
+        if ( strpos( $raw, '<script' ) === false ) {
+            wp_print_inline_script_tag( $raw, [ 'id' => "newrelic-browser-{$where}-raw" ] );
+        } else {
+            echo $raw; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscape.OutputNotEscaped
+        }
+        return;
+    }
+
+	// 4) Nothing available.
 	echo "\n<!-- NR diag {$where}: no snippet returned -->\n";
 }
 

--- a/web/app/mu-plugins/newrelic.php
+++ b/web/app/mu-plugins/newrelic.php
@@ -23,6 +23,7 @@ function get_newrelic_inline( string $where ) : void {
 	$fn = $where === 'footer' ? 'newrelic_get_browser_timing_footer' : 'newrelic_get_browser_timing_header';
 
 	if ( ! function_exists( $fn ) ) {
+        echo "\n<!-- NR diag {$where} function {$fn} does not exist -->\n";
 		return;
 	}
 


### PR DESCRIPTION
OpenGraph tags are not working to unfurl link info in Slack (and likely other things). ChatGPT seems to think this is because New Relic's script is being called early in the execution. 

This PR disables New Relic's auto-embedded script and manually adds it lower in the priority of WP execution to Yoast can handle the OG stuff first before New Relic is added.