### PR TITLE
test: remove EP features POST alias to verify Cloudflare fix

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -49,6 +49,23 @@ if (
 }
 
 /**
+ * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer.
+ * This must run before application.pantheon.php so that WP_HOME is defined with the
+ * correct https:// scheme — otherwise WP_CONTENT_URL (derived from WP_HOME) is http://,
+ * which causes media/attachment URLs and Yoast og:image tags to use the wrong scheme.
+ * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
+ */
+if ( php_sapi_name() === 'cli' && ! isset( $_SERVER['HTTPS'] ) ) {
+	// Ensure CLI contexts (e.g., wp-cli reindex) treat the site as HTTPS.
+	$_SERVER['HTTPS'] = 'on';
+	$_SERVER['SERVER_PORT'] = 443;
+	$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+}
+if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ) {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+/**
  * Include Pantheon application settings.
  */
 require_once __DIR__ . '/application.pantheon.php';
@@ -146,20 +163,6 @@ if ( $_ENV['PANTHEON_ENVIRONMENT'] === 'dev' || isset( $_ENV['LANDO'] ) ) {
 Config::define( 'FORCE_SSL_ADMIN', true );
 Config::define( 'FORCE_SSL_LOGIN', true );
 Config::define( 'FORCE_SSL', true );
-
-/**
- * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer
- * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
- */
-if ( php_sapi_name() === 'cli' && ! isset( $_SERVER['HTTPS'] ) ) {
-	// Ensure CLI contexts (e.g., wp-cli reindex) treat the site as HTTPS.
-	$_SERVER['HTTPS'] = 'on';
-	$_SERVER['SERVER_PORT'] = 443;
-	$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
-}
-if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ) {
-	$_SERVER['HTTPS'] = 'on';
-}
 
 if ( ! function_exists( 'pantheon_get_secret' ) ) {
 	/**

--- a/web/app/mu-plugins/community-code-elasticpress/plugin.php
+++ b/web/app/mu-plugins/community-code-elasticpress/plugin.php
@@ -28,34 +28,6 @@ function init() {
 	add_filter( 'ep_related_posts_fields', __NAMESPACE__ . '\\add_transcript_to_related_posts_fields' );
 	add_filter( 'ep_post_mapping', __NAMESPACE__ . '\\add_transcript_field_mapping' );
 	add_filter( 'ep_formatted_args', __NAMESPACE__ . '\\customize_related_posts_query', 999, 3 );
-
-	// Cloudflare blocks PUT from browser User-Agents, so also register POST for the
-	// features endpoint so EP's JS fallback succeeds.
-	add_action( 'rest_api_init', __NAMESPACE__ . '\\register_ep_features_post_route', 20 );
-}
-
-/**
- * Register a POST alias for the EP features REST route.
- *
- * Cloudflare's bot protection blocks PUT requests from browser User-Agents,
- * causing ElasticPress's JS to fall back to POST. The upstream route only
- * registers PUT, so the POST returns "no route found". This adds a matching
- * POST handler pointing to the same callback.
- */
-function register_ep_features_post_route() {
-	if ( ! class_exists( '\\ElasticPress\\REST\\Features' ) ) {
-		return;
-	}
-	$controller = new \ElasticPress\REST\Features();
-	register_rest_route(
-		'elasticpress/v1',
-		'/features',
-		[
-			'methods'             => 'POST',
-			'callback'            => [ $controller, 'update_settings' ],
-			'permission_callback' => [ $controller, 'check_permission' ],
-		]
-	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the POST alias workaround for the EP features REST route to test whether Cloudflare's WAF rules have been updated to allow PUT requests through.

**Do not merge.** This is a test-only branch. Once confirmed, either:
- Delete if Cloudflare fix is confirmed (and remove workaround from main)
- Close if Cloudflare is still blocking (and keep workaround on main)

## Test plan

- [ ] Build multidev from this PR
- [ ] Log into WP admin on the multidev
- [ ] Navigate to ElasticPress → Features
- [ ] Try to save feature settings
- [ ] Check browser Network tab — if PUT succeeds → Cloudflare fixed, if it fails → workaround still needed