### PR TITLE
fix: configure Dependabot private registry for Object Cache Pro

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
 version: 2
+registries:
+  objectcache-pro:
+    type: composer-repository
+    url: https://objectcache.pro/repo/
+    username: token
+    password: ${{secrets.OBJECTCACHE_PRO_TOKEN}}
 updates:
   - package-ecosystem: composer
     directory: "/"
+    registries:
+      - objectcache-pro
     schedule:
       interval: daily
     open-pull-requests-limit: 99


### PR DESCRIPTION
## Summary

- Adds a `registries` block to `dependabot.yml` for `objectcache.pro`
- References a new `OBJECTCACHE_PRO_TOKEN` Dependabot secret for auth
- Wires the registry into the composer update config

## Context

Dependabot's Composer update job was failing with a 401 on `objectcache.pro` despite a `COMPOSER_AUTH` Dependabot secret being set. Root cause: `COMPOSER_AUTH` is not injected into Dependabot's updater container — credentials need to go through `GITHUB_REGISTRIES_PROXY`, which requires an explicit `registries:` declaration in `dependabot.yml`.

## Before merging

Add `OBJECTCACHE_PRO_TOKEN` to Dependabot secrets (Settings → Secrets and variables → Dependabot) with the Object Cache Pro license key as the value. The existing `COMPOSER_AUTH` secret can be deleted.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)