### PR TITLE
feat: group Dependabot Composer updates by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       interval: daily
     open-pull-requests-limit: 99
     target-branch: main
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- Groups Composer dependency updates into two PRs: one for production deps, one for dev deps
- Replaces the previous one-PR-per-package behavior

## Test plan

- [ ] Merge and trigger a Dependabot check from the Dependabot UI tab
- [ ] Confirm grouped PRs appear instead of individual ones

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)