### PR TITLE
perf(template-canvas): cache Grid Aware Electricity Maps call to fix render-path external request

### DIFF
--- a/web/app/mu-plugins/grid-aware-intensity-cache.php
+++ b/web/app/mu-plugins/grid-aware-intensity-cache.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Plugin Name: Grid Aware Intensity – shared render-path cache
+ * Description: Wraps the third-party Grid Aware WP plugin's Electricity Maps API
+ *              call with a site-wide persistent cache so the front-end render path
+ *              (template-canvas) no longer blocks on a per-visitor external request.
+ * Author:      Community + Code
+ * License:     MIT License
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * grid-aware-wp (web/app/plugins/grid-aware-wp) calls the Electricity Maps API on
+ * EVERY request — once when its main file loads and again on `wp_body_open`. Its
+ * own transient is keyed per visitor IP (md5 of the IP), so on a public site the
+ * cache almost never hits: each new visitor triggers a fresh wp_remote_get with a
+ * 10s timeout on the hot path, and upstream failures are never cached. That is the
+ * tail behind the slow `WebTransaction/Action/template-canvas` p95.
+ *
+ * grid-aware-wp is third-party code, so instead of editing it we intercept its
+ * outbound HTTP calls through the WordPress HTTP API filters and serve a single
+ * site-wide cached response. mu-plugins load before regular plugins, so this
+ * filter is registered before grid-aware-wp's load-time call fires.
+ *
+ * Trade-off: the upstream value becomes site-wide rather than per-visitor-IP. The
+ * intensity is a coarse low/medium/high bucket and the plugin still exposes the
+ * manual `?grid_intensity=` switcher, so a shared value is an acceptable
+ * approximation in exchange for removing a per-visitor blocking external call.
+ */
+
+namespace CommunityCode\GridAwareIntensityCache;
+
+const API_HOST    = 'api.electricitymap.org';
+const CACHE_KEY   = 'cc_gaw_em_intensity_shared';
+const HIT_TTL     = 600; // Match the plugin's own 10-minute freshness window.
+const MISS_TTL    = 120; // Short TTL so upstream failures don't retry every request.
+const LOCK_TTL    = 30;  // Brief placeholder to prevent a cold-window stampede.
+const HOT_TIMEOUT = 2;   // Hard cap on render-path blocking (plugin default is 10s).
+
+/**
+ * Is this HTTP request the Electricity Maps API call we want to cache?
+ *
+ * @param string $url Request URL.
+ * @return bool
+ */
+function is_target_request( $url ) : bool {
+	return is_string( $url ) && false !== strpos( $url, API_HOST );
+}
+
+/**
+ * Build a minimal, serialize-safe HTTP response array that the plugin can parse
+ * with wp_remote_retrieve_response_code() / wp_remote_retrieve_body().
+ *
+ * @param int    $code HTTP status code.
+ * @param string $body Response body.
+ * @return array
+ */
+function make_response( int $code, string $body ) : array {
+	return [
+		'headers'       => [],
+		'body'          => $body,
+		'response'      => [
+			'code'    => $code,
+			'message' => 200 === $code ? 'OK' : 'Service Unavailable',
+		],
+		'cookies'       => [],
+		'http_response' => null,
+	];
+}
+
+/**
+ * A safe fallback the plugin maps to the 'low' intensity level.
+ *
+ * @return array
+ */
+function fallback_response() : array {
+	return make_response(
+		200,
+		wp_json_encode(
+			[
+				'zone' => 'unknown',
+				'data' => [
+					[
+						'level'    => 'low',
+						'datetime' => null,
+					],
+				],
+			]
+		)
+	);
+}
+
+/**
+ * Cap the render-path timeout for the Electricity Maps call.
+ *
+ * @param array  $args HTTP request args.
+ * @param string $url  Request URL.
+ * @return array
+ */
+function cap_timeout( $args, $url ) {
+	if ( is_target_request( $url ) ) {
+		$args['timeout'] = HOT_TIMEOUT;
+	}
+	return $args;
+}
+add_filter( 'http_request_args', __NAMESPACE__ . '\\cap_timeout', 10, 2 );
+
+/**
+ * Short-circuit the Electricity Maps call with a site-wide cached response.
+ *
+ * Cold-miss policy: if nothing is cached yet, prime a brief placeholder (acts as a
+ * stampede lock) and let THIS one request perform the real fetch — capped at
+ * HOT_TIMEOUT by cap_timeout(). The genuine response is captured in
+ * capture_response() below and cached site-wide for HIT_TTL.
+ *
+ * @param false|array $pre  Short-circuit value (false to proceed normally).
+ * @param array       $args HTTP request args.
+ * @param string      $url  Request URL.
+ * @return false|array
+ */
+function short_circuit( $pre, $args, $url ) {
+	if ( false !== $pre || ! is_target_request( $url ) ) {
+		return $pre;
+	}
+
+	$cached = get_transient( CACHE_KEY );
+	if ( false !== $cached ) {
+		// Hit (real value, fallback, or placeholder): serve without a network call.
+		return $cached;
+	}
+
+	// Cold miss: prime a short-lived placeholder so concurrent requests in this
+	// window are served instantly instead of all stampeding the upstream API, then
+	// allow this single request through to fetch the real value.
+	set_transient( CACHE_KEY, fallback_response(), LOCK_TTL );
+	return false;
+}
+add_filter( 'pre_http_request', __NAMESPACE__ . '\\short_circuit', 10, 3 );
+
+/**
+ * Capture the genuine Electricity Maps response and cache it site-wide.
+ *
+ * On success (HTTP 200) the real response is cached for HIT_TTL. On any failure the
+ * fallback is cached for the shorter MISS_TTL — so upstream errors are cached
+ * (negative caching) rather than retried on every subsequent render — and the
+ * fallback is returned so the current request still renders.
+ *
+ * @param array  $response Parsed HTTP response.
+ * @param array  $args     HTTP request args.
+ * @param string $url      Request URL.
+ * @return array
+ */
+function capture_response( $response, $args, $url ) {
+	if ( ! is_target_request( $url ) ) {
+		return $response;
+	}
+
+	$code = (int) wp_remote_retrieve_response_code( $response );
+	$body = wp_remote_retrieve_body( $response );
+
+	if ( 200 === $code && '' !== $body ) {
+		$cacheable = make_response( 200, $body );
+		set_transient( CACHE_KEY, $cacheable, HIT_TTL );
+		return $cacheable;
+	}
+
+	$fallback = fallback_response();
+	set_transient( CACHE_KEY, $fallback, MISS_TTL );
+	return $fallback;
+}
+add_filter( 'http_response', __NAMESPACE__ . '\\capture_response', 10, 3 );

--- a/web/app/mu-plugins/grid-aware-intensity-cache.php
+++ b/web/app/mu-plugins/grid-aware-intensity-cache.php
@@ -47,6 +47,20 @@ function is_target_request( $url ) : bool {
 }
 
 /**
+ * Re-entrancy flag so our own cold-miss fetch isn't intercepted by short_circuit().
+ *
+ * @param bool|null $set Pass true/false to set, null to read.
+ * @return bool
+ */
+function is_fetching( $set = null ) : bool {
+	static $state = false;
+	if ( null !== $set ) {
+		$state = (bool) $set;
+	}
+	return $state;
+}
+
+/**
  * Build a minimal, serialize-safe HTTP response array that the plugin can parse
  * with wp_remote_retrieve_response_code() / wp_remote_retrieve_body().
  *
@@ -69,6 +83,10 @@ function make_response( int $code, string $body ) : array {
 
 /**
  * A safe fallback the plugin maps to the 'low' intensity level.
+ *
+ * The body mimics the RAW Electricity Maps API JSON (keyed `data[].level`, the
+ * pre-normalized schema the plugin parses in get_current_intensity_level_direct),
+ * not the plugin's normalized `intensity_level` output.
  *
  * @return array
  */
@@ -107,18 +125,20 @@ add_filter( 'http_request_args', __NAMESPACE__ . '\\cap_timeout', 10, 2 );
 /**
  * Short-circuit the Electricity Maps call with a site-wide cached response.
  *
- * Cold-miss policy: if nothing is cached yet, prime a brief placeholder (acts as a
- * stampede lock) and let THIS one request perform the real fetch — capped at
- * HOT_TIMEOUT by cap_timeout(). The genuine response is captured in
- * capture_response() below and cached site-wide for HIT_TTL.
+ * On a warm cache, returns the cached response without any network call. On a cold
+ * miss it primes a brief placeholder (a stampede lock so concurrent requests in the
+ * cold window are served instantly), then performs ONE upstream fetch itself — so
+ * success, HTTP errors, AND transport-level WP_Errors are all caught and cached in
+ * a single place rather than relying on the http_response filter (which never fires
+ * for transport failures).
  *
- * @param false|array $pre  Short-circuit value (false to proceed normally).
- * @param array       $args HTTP request args.
- * @param string      $url  Request URL.
- * @return false|array
+ * @param false|array|\WP_Error $pre  Short-circuit value (false to proceed normally).
+ * @param array                 $args HTTP request args.
+ * @param string                $url  Request URL.
+ * @return false|array|\WP_Error
  */
 function short_circuit( $pre, $args, $url ) {
-	if ( false !== $pre || ! is_target_request( $url ) ) {
+	if ( false !== $pre || is_fetching() || ! is_target_request( $url ) ) {
 		return $pre;
 	}
 
@@ -129,42 +149,35 @@ function short_circuit( $pre, $args, $url ) {
 	}
 
 	// Cold miss: prime a short-lived placeholder so concurrent requests in this
-	// window are served instantly instead of all stampeding the upstream API, then
-	// allow this single request through to fetch the real value.
+	// window are served instantly instead of all stampeding the upstream API.
 	set_transient( CACHE_KEY, fallback_response(), LOCK_TTL );
-	return false;
-}
-add_filter( 'pre_http_request', __NAMESPACE__ . '\\short_circuit', 10, 3 );
 
-/**
- * Capture the genuine Electricity Maps response and cache it site-wide.
- *
- * On success (HTTP 200) the real response is cached for HIT_TTL. On any failure the
- * fallback is cached for the shorter MISS_TTL — so upstream errors are cached
- * (negative caching) rather than retried on every subsequent render — and the
- * fallback is returned so the current request still renders.
- *
- * @param array  $response Parsed HTTP response.
- * @param array  $args     HTTP request args.
- * @param string $url      Request URL.
- * @return array
- */
-function capture_response( $response, $args, $url ) {
-	if ( ! is_target_request( $url ) ) {
-		return $response;
+	// Perform the single cold-miss fetch ourselves (re-entrancy guarded so this
+	// filter doesn't intercept it). Timeout is capped by cap_timeout().
+	is_fetching( true );
+	$response = wp_remote_request( $url, $args );
+	is_fetching( false );
+
+	if ( is_wp_error( $response ) ) {
+		// Transport failure (DNS, refused, SSL, timeout): negative-cache the
+		// fallback for MISS_TTL so we don't retry the dead upstream every request.
+		$fallback = fallback_response();
+		set_transient( CACHE_KEY, $fallback, MISS_TTL );
+		return $fallback;
 	}
 
 	$code = (int) wp_remote_retrieve_response_code( $response );
 	$body = wp_remote_retrieve_body( $response );
 
 	if ( 200 === $code && '' !== $body ) {
-		$cacheable = make_response( 200, $body );
-		set_transient( CACHE_KEY, $cacheable, HIT_TTL );
-		return $cacheable;
+		$real = make_response( 200, $body );
+		set_transient( CACHE_KEY, $real, HIT_TTL );
+		return $real;
 	}
 
+	// Non-200 HTTP response: negative-cache the fallback for the short MISS_TTL.
 	$fallback = fallback_response();
 	set_transient( CACHE_KEY, $fallback, MISS_TTL );
 	return $fallback;
 }
-add_filter( 'http_response', __NAMESPACE__ . '\\capture_response', 10, 3 );
+add_filter( 'pre_http_request', __NAMESPACE__ . '\\short_circuit', 10, 3 );


### PR DESCRIPTION
## Slow transaction

| Metric | Value |
| --- | --- |
| Transaction | `WebTransaction/Action/template-canvas` |
| p95 | 3078 ms |
| p99 | 3766 ms |
| Threshold | 1000 ms |
| Samples | 1025 |
| DB avg | 82 ms |
| External (HTTP) avg | 264 ms |

`template-canvas` is `wp-includes/template-canvas.php` — the PHP file WordPress loads for **every** block-theme front-end render. So this transaction covers all front-end pages.

## Diagnosis

Neither the DB average (82 ms, 2.7% of p95) nor the external average (264 ms, 8.6%) dominates the *average*, but the average is misleading here. The third-party **grid-aware-wp** plugin (`web/app/plugins/grid-aware-wp`) calls the Electricity Maps API on the render path on **every** request:

- At plugin load — `grid-aware-wp.php:39` (`get_current_intensity_level()` runs unconditionally).
- Again on `wp_body_open` — `grid-aware-wp.php:119`.

Its own cache (`includes/class-electricity-maps-api.php`) has three problems:

1. **Keyed per visitor IP** — `grid_aware_wp_cil_<md5(IP)>` (`class-electricity-maps-api.php:112`). On a public site the transient almost never hits; each new visitor IP is a fresh `wp_remote_get`.
2. **10-second timeout** (`class-electricity-maps-api.php:102`) — a render-path eternity.
3. **Negative results never cached** — `WP_Error` paths (`:124, :153, :166, :214`) return without `set_transient`, so when upstream is slow/erroring every subsequent request retries on the hot path.

The diluted `ext_avg` of 264 ms with p95 = 3078 ms fits this exactly: ~10% cold-miss requests at ~2.5 s + ~90% cache hits ≈ 250 ms average, while the slow tail (p95/p99) **is** the cold-miss external calls. This is the EXTERNAL-DOMINANT pattern masked in the average by an ineffective per-IP cache.

## Lever pulled — cache an expensive external call

`grid-aware-wp` is third-party, so it is **not edited**. New mu-plugin `web/app/mu-plugins/grid-aware-intensity-cache.php` wraps the outbound call via the WordPress HTTP API filters:

- `pre_http_request` — serves a single **site-wide** persistent transient (`cc_gaw_em_intensity_shared`) so no per-visitor network call happens on the hot path.
- `http_request_args` — caps the render-path timeout at **2 s** (down from 10 s).
- `http_response` — captures the genuine upstream response and caches it site-wide for 10 min.

mu-plugins load before regular plugins, so the filter is registered before grid-aware-wp's load-time call fires. Because both call sites funnel through `wp_remote_get`, wrapping the HTTP layer fixes both at once.

## Gotcha addressed — cold-miss policy

A transient alone does not fix the cold-miss case, so the policy is explicit:

- **Short timeout + skip**: cold-miss requests are capped at 2 s, not 10 s.
- **Placeholder / stampede lock**: on a true cold miss the cache is primed with a brief (30 s) `low` placeholder before letting *one* request fetch the real value, so concurrent requests in the cold window are served instantly instead of all stampeding the upstream API.
- **Negative caching**: upstream failures cache the `low` fallback for a short 120 s TTL and return it, so errors don't retry on every render.
- On success the genuine response is cached site-wide for 600 s (matching the plugin's own freshness window).

**Behavior trade-off** (documented in the file header): the intensity value becomes site-wide rather than per-visitor-IP. The value is a coarse low/medium/high bucket and the plugin still exposes the manual `?grid_intensity=` switcher, so a shared value is an acceptable approximation in exchange for removing a per-visitor blocking external call.

## Scope check

- **Is the root cause data / a one-shot op?** No. It is code on the render path (an external call with an ineffective cache). No options-table edit, cache flush, or autoload change would fix it — the call would still fire per visitor. A code wrap is required.
- **Does core/a standard plugin already do this?** The fix uses the canonical Transients API for the persistent cache and core HTTP API filters for the override — no custom cache class, no rolled-own caching.
- **No memory / execution-time bumps.**
- **Did not edit third-party plugin files** (`web/app/plugins/grid-aware-wp/*`) — overridden via hooks in a mu-plugin.

### Secondary observation (not addressed — separate fix class)
`grid-aware-wp/includes/class-grid-aware-wp-server.php:filter_image_block()` calls `getimagesize()` (disk/network-FS read) per image block via `render_block_core/image`. This can add render-path I/O on image-heavy pages, but it is scoped to image blocks and is a distinct fix class, so it is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## GATE 1 — backend performance review (`reviewer-performance-backend`)

**Result: PASS** (no CRITICAL/HIGH/MEDIUM findings on the final revision).

The first review pass raised two MEDIUM findings, both fixed in commit `63de7fb` and confirmed resolved on re-review:
- **M1** — transport-level `WP_Error` failures bypassed the `http_response` filter, so they were only held back for the 30s lock TTL instead of being negative-cached. Fixed by consolidating the single cold-miss fetch into the `pre_http_request` short-circuit (re-entrancy guarded via `is_fetching()`), so success (600s), non-200 (120s), and `WP_Error` transport failures (120s) are all handled in one place.
- **M2** — missing `is_wp_error()` guard before consuming the response body. Fixed.

### Categories reviewed (final pass)

| Category | Findings |
| --- | --- |
| Database Queries | 0 |
| N+1 Query Patterns | 0 |
| Caching | 1 LOW (L1, see below) |
| External API / Remote Requests | 0 |
| Hooks | 0 |
| Scalability | 0 |

**Known limitation (L1, LOW — not blocking):** the cold-miss stampede lock uses a non-atomic `get_transient`/`set_transient` check-then-set, and `is_fetching()` is per-PHP-process. Under concurrent cold-start load several FPM workers may each perform one upstream fetch before the 600s value is written. The blast radius is bounded and self-limiting (each fetch capped at 2s; once any worker writes the cache, all subsequent requests hit it). A future hardening would use `wp_cache_add()` as an atomic lock token. Out of scope for this single-lever fix.
