### PR TITLE
feat(search-analytics): suggested tags from frequently searched terms

### DIFF
--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -19,6 +19,17 @@ function get_rows_per_page(): int {
 }
 
 /**
+ * Minimum number of searches required to surface a term as a suggested tag.
+ *
+ * @since 1.2.0
+ * @return int
+ */
+function get_min_count(): int {
+	$saved = (int) get_user_meta( get_current_user_id(), 'cc_search_analytics_min_count', true );
+	return $saved > 0 ? $saved : 1;
+}
+
+/**
  * Default analytics period in days. 0 = all time.
  *
  * Uses the empty-string check because 0 is a valid saved value (all time).
@@ -52,8 +63,9 @@ function render_screen_options( string $settings, \WP_Screen $screen ): string {
 		return $settings;
 	}
 
-	$rows   = get_rows_per_page();
-	$period = get_default_period();
+	$rows      = get_rows_per_page();
+	$min_count = get_min_count();
+	$period    = get_default_period();
 	$valid_periods = [ 7 => __( '7 days', 'community-code' ), 30 => __( '30 days', 'community-code' ), 90 => __( '90 days', 'community-code' ), 0 => __( 'All time', 'community-code' ) ];
 
 	ob_start();
@@ -64,6 +76,14 @@ function render_screen_options( string $settings, \WP_Screen $screen ): string {
 			<?php esc_html_e( 'Number of rows:', 'community-code' ); ?>
 			<input type="number" id="cc-sa-rows" name="cc_search_analytics_rows"
 				value="<?php echo esc_attr( $rows ); ?>" min="1" max="200" step="1" class="small-text" />
+		</label>
+	</fieldset>
+	<fieldset class="screen-options">
+		<legend><?php esc_html_e( 'Suggested Tags', 'community-code' ); ?></legend>
+		<label for="cc-sa-min-count">
+			<?php esc_html_e( 'Minimum searches to suggest:', 'community-code' ); ?>
+			<input type="number" id="cc-sa-min-count" name="cc_search_analytics_min_count"
+				value="<?php echo esc_attr( $min_count ); ?>" min="1" max="100" step="1" class="small-text" />
 		</label>
 	</fieldset>
 	<fieldset class="screen-options">
@@ -107,6 +127,9 @@ function handle_screen_options(): void {
 	if ( isset( $_POST['cc_search_analytics_rows'] ) ) {
 		update_user_meta( $user_id, 'cc_search_analytics_rows', max( 1, min( 200, (int) $_POST['cc_search_analytics_rows'] ) ) );
 	}
+	if ( isset( $_POST['cc_search_analytics_min_count'] ) ) {
+		update_user_meta( $user_id, 'cc_search_analytics_min_count', max( 1, min( 100, (int) $_POST['cc_search_analytics_min_count'] ) ) );
+	}
 	if ( isset( $_POST['cc_search_analytics_period'] ) ) {
 		$val = (int) $_POST['cc_search_analytics_period'];
 		if ( in_array( $val, [ 7, 30, 90, 0 ], true ) ) {
@@ -133,6 +156,8 @@ function save_screen_option( $status, string $option, $value ) {
 	switch ( $option ) {
 		case 'cc_search_analytics_rows':
 			return max( 1, min( 200, (int) $value ) );
+		case 'cc_search_analytics_min_count':
+			return max( 1, min( 100, (int) $value ) );
 		case 'cc_search_analytics_period':
 			$val = (int) $value;
 			return in_array( $val, [ 7, 30, 90, 0 ], true ) ? $val : $status;
@@ -382,7 +407,7 @@ function render_admin_page(): void {
  * @return void
  */
 function render_suggested_tags( int $days ): void {
-	$gaps = get_tag_gaps( 3, $days );
+	$gaps = get_tag_gaps( get_min_count(), $days );
 
 	if ( empty( $gaps ) ) {
 		echo '<p class="sa-zero">' . esc_html__( 'No suggested tags — all frequently searched terms already exist as tags.', 'community-code' ) . '</p>';

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -417,45 +417,57 @@ function render_suggested_tags( int $days ): void {
 	$using_ai = ai_is_available();
 	$slugs = normalize_terms_with_ai( $gaps );
 	$nonce = wp_create_nonce( 'cc-create-tag' );
+
+	// Pre-fetch candidate posts and discard terms with no matches.
+	$rows = [];
+	foreach ( $gaps as $gap ) {
+		$posts = get_posts_for_term( $gap['term'], 5 );
+		if ( empty( $posts ) ) {
+			continue;
+		}
+		$rows[] = [
+			'term'  => $gap['term'],
+			'count' => $gap['count'],
+			'slug'  => $slugs[ $gap['term'] ] ?? sanitize_title( $gap['term'] ),
+			'posts' => $posts,
+		];
+	}
+
+	if ( empty( $rows ) ) {
+		echo '<p class="sa-zero">' . esc_html__( 'No suggested tags — all frequently searched terms either already exist as tags or matched no posts.', 'community-code' ) . '</p>';
+		return;
+	}
 	?>
 	<?php if ( $using_ai ) : ?>
 	<p><em><?php esc_html_e( 'Canonical slugs are AI-assisted suggestions.', 'community-code' ); ?></em></p>
 	<?php else : ?>
 	<p><em><?php esc_html_e( 'Install and configure the AI plugin to get AI-assisted slug suggestions.', 'community-code' ); ?></em></p>
 	<?php endif; ?>
-	<table class="wp-list-table widefat fixed striped" style="margin-top:0">
+	<table class="wp-list-table widefat striped" style="margin-top:0;table-layout:auto">
 		<thead>
 			<tr>
-				<th><?php esc_html_e( 'Term', 'community-code' ); ?></th>
-				<th style="width:80px"><?php esc_html_e( 'Searches', 'community-code' ); ?></th>
-				<th><?php esc_html_e( 'Suggested slug', 'community-code' ); ?></th>
-				<th style="width:120px"><?php esc_html_e( 'Candidate posts', 'community-code' ); ?></th>
-				<th style="width:130px"><?php esc_html_e( 'Action', 'community-code' ); ?></th>
+				<th style="width:15%"><?php esc_html_e( 'Term', 'community-code' ); ?></th>
+				<th style="width:70px"><?php esc_html_e( 'Searches', 'community-code' ); ?></th>
+				<th style="width:18%"><?php esc_html_e( 'Suggested slug', 'community-code' ); ?></th>
+				<th><?php esc_html_e( 'Candidate posts', 'community-code' ); ?></th>
+				<th style="width:110px"><?php esc_html_e( 'Action', 'community-code' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
-		<?php foreach ( $gaps as $gap ) :
-			$term = $gap['term'];
-			$slug = $slugs[ $term ] ?? sanitize_title( $term );
-			$posts = get_posts_for_term( $term, 5 );
-		?>
+		<?php foreach ( $rows as $row ) : ?>
 		<tr>
-			<td><?php echo esc_html( $term ); ?></td>
-			<td><?php echo esc_html( number_format_i18n( (int) $gap['count'] ) ); ?></td>
-			<td><code><?php echo esc_html( $slug ); ?></code></td>
+			<td><?php echo esc_html( $row['term'] ); ?></td>
+			<td><?php echo esc_html( number_format_i18n( (int) $row['count'] ) ); ?></td>
+			<td><code><?php echo esc_html( $row['slug'] ); ?></code></td>
 			<td>
-				<?php if ( $posts ) : ?>
-					<?php foreach ( $posts as $post ) : ?>
-						<a href="<?php echo esc_url( $post['edit_url'] ); ?>" target="_blank" style="display:block;font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px" title="<?php echo esc_attr( $post['title'] ); ?>"><?php echo esc_html( $post['title'] ); ?></a>
-					<?php endforeach; ?>
-				<?php else : ?>
-					<span class="sa-zero"><?php esc_html_e( 'None found', 'community-code' ); ?></span>
-				<?php endif; ?>
+				<?php foreach ( $row['posts'] as $post ) : ?>
+					<a href="<?php echo esc_url( $post['edit_url'] ); ?>" target="_blank" style="display:block;font-size:12px" title="<?php echo esc_attr( $post['title'] ); ?>"><?php echo esc_html( $post['title'] ); ?></a>
+				<?php endforeach; ?>
 			</td>
 			<td>
 				<button class="button button-small cc-create-tag"
-					data-term="<?php echo esc_attr( $term ); ?>"
-					data-slug="<?php echo esc_attr( $slug ); ?>"
+					data-term="<?php echo esc_attr( $row['term'] ); ?>"
+					data-slug="<?php echo esc_attr( $row['slug'] ); ?>"
 					data-nonce="<?php echo esc_attr( $nonce ); ?>">
 					<?php esc_html_e( 'Create tag', 'community-code' ); ?>
 				</button>

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -63,9 +63,9 @@ function render_screen_options( string $settings, \WP_Screen $screen ): string {
 		return $settings;
 	}
 
-	$rows      = get_rows_per_page();
+	$rows = get_rows_per_page();
 	$min_count = get_min_count();
-	$period    = get_default_period();
+	$period = get_default_period();
 	$valid_periods = [ 7 => __( '7 days', 'community-code' ), 30 => __( '30 days', 'community-code' ), 90 => __( '90 days', 'community-code' ), 0 => __( 'All time', 'community-code' ) ];
 
 	ob_start();
@@ -481,10 +481,10 @@ function render_suggested_tags( int $days ): void {
 	( function () {
 		document.querySelectorAll( '.cc-create-tag' ).forEach( function ( btn ) {
 			btn.addEventListener( 'click', function () {
-				var term    = btn.dataset.term;
-				var slug    = btn.dataset.slug;
+				var term = btn.dataset.term;
+				var slug = btn.dataset.slug;
 				var postIds = btn.dataset.postIds;
-				var nonce   = btn.dataset.nonce;
+				var nonce = btn.dataset.nonce;
 				btn.disabled = true;
 				btn.textContent = '<?php echo esc_js( __( 'Applying…', 'community-code' ) ); ?>';
 				fetch( ajaxurl, {
@@ -543,7 +543,7 @@ function handle_create_analytics_tag(): void {
 		wp_send_json_error( $result->get_error_message() );
 	}
 
-	$tag_id  = $result['term_id'];
+	$tag_id = $result['term_id'];
 	$applied = 0;
 
 	$raw_ids = sanitize_text_field( wp_unslash( $_POST['post_ids'] ?? '' ) );

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -421,7 +421,7 @@ function render_suggested_tags( int $days ): void {
 	// Pre-fetch candidate posts and discard terms with no matches.
 	$rows = [];
 	foreach ( $gaps as $gap ) {
-		$posts = get_posts_for_term( $gap['term'], 5 );
+		$posts = get_posts_for_term( $gap['term'], 10 );
 		if ( empty( $posts ) ) {
 			continue;
 		}

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -468,8 +468,9 @@ function render_suggested_tags( int $days ): void {
 				<button class="button button-small cc-create-tag"
 					data-term="<?php echo esc_attr( $row['term'] ); ?>"
 					data-slug="<?php echo esc_attr( $row['slug'] ); ?>"
+					data-post-ids="<?php echo esc_attr( implode( ',', array_column( $row['posts'], 'ID' ) ) ); ?>"
 					data-nonce="<?php echo esc_attr( $nonce ); ?>">
-					<?php esc_html_e( 'Create tag', 'community-code' ); ?>
+					<?php esc_html_e( 'Create &amp; apply tag', 'community-code' ); ?>
 				</button>
 			</td>
 		</tr>
@@ -480,11 +481,12 @@ function render_suggested_tags( int $days ): void {
 	( function () {
 		document.querySelectorAll( '.cc-create-tag' ).forEach( function ( btn ) {
 			btn.addEventListener( 'click', function () {
-				var term  = btn.dataset.term;
-				var slug  = btn.dataset.slug;
-				var nonce = btn.dataset.nonce;
+				var term    = btn.dataset.term;
+				var slug    = btn.dataset.slug;
+				var postIds = btn.dataset.postIds;
+				var nonce   = btn.dataset.nonce;
 				btn.disabled = true;
-				btn.textContent = '<?php echo esc_js( __( 'Creating…', 'community-code' ) ); ?>';
+				btn.textContent = '<?php echo esc_js( __( 'Applying…', 'community-code' ) ); ?>';
 				fetch( ajaxurl, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -492,6 +494,7 @@ function render_suggested_tags( int $days ): void {
 						action: 'cc_create_analytics_tag',
 						term: term,
 						slug: slug,
+						post_ids: postIds,
 						nonce: nonce
 					} )
 				} ).then( function ( r ) { return r.json(); } ).then( function ( data ) {
@@ -540,5 +543,19 @@ function handle_create_analytics_tag(): void {
 		wp_send_json_error( $result->get_error_message() );
 	}
 
-	wp_send_json_success( [ 'term_id' => $result['term_id'] ] );
+	$tag_id  = $result['term_id'];
+	$applied = 0;
+
+	$raw_ids = sanitize_text_field( wp_unslash( $_POST['post_ids'] ?? '' ) );
+	if ( $raw_ids ) {
+		$post_ids = array_filter( array_map( 'absint', explode( ',', $raw_ids ) ) );
+		foreach ( $post_ids as $post_id ) {
+			if ( get_post( $post_id ) ) {
+				wp_set_post_tags( $post_id, [ $tag_id ], true );
+				$applied++;
+			}
+		}
+	}
+
+	wp_send_json_success( [ 'term_id' => $tag_id, 'applied' => $applied ] );
 }

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -359,7 +359,149 @@ function render_admin_page(): void {
 			<?php endif; ?>
 		</div>
 
+		<div class="sa-card">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Suggested Tags', 'community-code' ); ?></h2>
+			<?php render_suggested_tags( $days ); ?>
+		</div>
+
 		<?php endif; ?>
 	</div>
 	<?php
+}
+
+/**
+ * Render the Suggested Tags section of the analytics dashboard.
+ *
+ * Compares frequently searched terms against the post_tag taxonomy and surfaces
+ * terms that have no matching tag. Optionally uses the AI plugin to suggest
+ * canonical slugs when it is available and configured.
+ *
+ * @since 1.2.0
+ *
+ * @param int $days Analytics period passed from render_admin_page(). 0 = all time.
+ * @return void
+ */
+function render_suggested_tags( int $days ): void {
+	$gaps = get_tag_gaps( 3, $days );
+
+	if ( empty( $gaps ) ) {
+		echo '<p class="sa-zero">' . esc_html__( 'No suggested tags — all frequently searched terms already exist as tags.', 'community-code' ) . '</p>';
+		return;
+	}
+
+	$using_ai = ai_is_available();
+	$slugs = normalize_terms_with_ai( $gaps );
+	$nonce = wp_create_nonce( 'cc-create-tag' );
+	?>
+	<?php if ( $using_ai ) : ?>
+	<p><em><?php esc_html_e( 'Canonical slugs are AI-assisted suggestions.', 'community-code' ); ?></em></p>
+	<?php else : ?>
+	<p><em><?php esc_html_e( 'Install and configure the AI plugin to get AI-assisted slug suggestions.', 'community-code' ); ?></em></p>
+	<?php endif; ?>
+	<table class="wp-list-table widefat fixed striped" style="margin-top:0">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Term', 'community-code' ); ?></th>
+				<th style="width:80px"><?php esc_html_e( 'Searches', 'community-code' ); ?></th>
+				<th><?php esc_html_e( 'Suggested slug', 'community-code' ); ?></th>
+				<th style="width:120px"><?php esc_html_e( 'Candidate posts', 'community-code' ); ?></th>
+				<th style="width:130px"><?php esc_html_e( 'Action', 'community-code' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php foreach ( $gaps as $gap ) :
+			$term = $gap['term'];
+			$slug = $slugs[ $term ] ?? sanitize_title( $term );
+			$posts = get_posts_for_term( $term, 5 );
+		?>
+		<tr>
+			<td><?php echo esc_html( $term ); ?></td>
+			<td><?php echo esc_html( number_format_i18n( (int) $gap['count'] ) ); ?></td>
+			<td><code><?php echo esc_html( $slug ); ?></code></td>
+			<td>
+				<?php if ( $posts ) : ?>
+					<?php foreach ( $posts as $post ) : ?>
+						<a href="<?php echo esc_url( $post['edit_url'] ); ?>" target="_blank" style="display:block;font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px" title="<?php echo esc_attr( $post['title'] ); ?>"><?php echo esc_html( $post['title'] ); ?></a>
+					<?php endforeach; ?>
+				<?php else : ?>
+					<span class="sa-zero"><?php esc_html_e( 'None found', 'community-code' ); ?></span>
+				<?php endif; ?>
+			</td>
+			<td>
+				<button class="button button-small cc-create-tag"
+					data-term="<?php echo esc_attr( $term ); ?>"
+					data-slug="<?php echo esc_attr( $slug ); ?>"
+					data-nonce="<?php echo esc_attr( $nonce ); ?>">
+					<?php esc_html_e( 'Create tag', 'community-code' ); ?>
+				</button>
+			</td>
+		</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<script>
+	( function () {
+		document.querySelectorAll( '.cc-create-tag' ).forEach( function ( btn ) {
+			btn.addEventListener( 'click', function () {
+				var term  = btn.dataset.term;
+				var slug  = btn.dataset.slug;
+				var nonce = btn.dataset.nonce;
+				btn.disabled = true;
+				btn.textContent = '<?php echo esc_js( __( 'Creating…', 'community-code' ) ); ?>';
+				fetch( ajaxurl, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: new URLSearchParams( {
+						action: 'cc_create_analytics_tag',
+						term: term,
+						slug: slug,
+						nonce: nonce
+					} )
+				} ).then( function ( r ) { return r.json(); } ).then( function ( data ) {
+					if ( data.success ) {
+						btn.textContent = '<?php echo esc_js( __( 'Created', 'community-code' ) ); ?>';
+						btn.classList.add( 'button-primary' );
+					} else {
+						btn.disabled = false;
+						btn.textContent = '<?php echo esc_js( __( 'Create tag', 'community-code' ) ); ?>';
+						alert( data.data || '<?php echo esc_js( __( 'Something went wrong.', 'community-code' ) ); ?>' );
+					}
+				} );
+			} );
+		} );
+	} )();
+	</script>
+	<?php
+}
+
+/**
+ * AJAX handler: create a post_tag from a suggested analytics term.
+ *
+ * Expects POST fields: term, slug, nonce.
+ * Requires manage_categories capability.
+ *
+ * @since 1.2.0
+ * @return void
+ */
+function handle_create_analytics_tag(): void {
+	check_ajax_referer( 'cc-create-tag', 'nonce' );
+
+	if ( ! current_user_can( 'manage_categories' ) ) {
+		wp_send_json_error( __( 'Permission denied.', 'community-code' ) );
+	}
+
+	$term = sanitize_text_field( wp_unslash( $_POST['term'] ?? '' ) );
+	$slug = sanitize_title( wp_unslash( $_POST['slug'] ?? $term ) );
+
+	if ( ! $term ) {
+		wp_send_json_error( __( 'Term is required.', 'community-code' ) );
+	}
+
+	$result = wp_insert_term( $term, 'post_tag', [ 'slug' => $slug ] );
+
+	if ( is_wp_error( $result ) ) {
+		wp_send_json_error( $result->get_error_message() );
+	}
+
+	wp_send_json_success( [ 'term_id' => $result['term_id'] ] );
 }

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -421,7 +421,7 @@ function render_suggested_tags( int $days ): void {
 	// Pre-fetch candidate posts and discard terms with no matches.
 	$rows = [];
 	foreach ( $gaps as $gap ) {
-		$posts = get_posts_for_term( $gap['term'], 10 );
+		$posts = get_posts_for_term( $gap['term'] );
 		if ( empty( $posts ) ) {
 			continue;
 		}

--- a/web/app/mu-plugins/search-analytics/includes/admin.php
+++ b/web/app/mu-plugins/search-analytics/includes/admin.php
@@ -26,7 +26,7 @@ function get_rows_per_page(): int {
  */
 function get_min_count(): int {
 	$saved = (int) get_user_meta( get_current_user_id(), 'cc_search_analytics_min_count', true );
-	return $saved > 0 ? $saved : 1;
+	return $saved > 0 ? $saved : 5;
 }
 
 /**

--- a/web/app/mu-plugins/search-analytics/includes/cli.php
+++ b/web/app/mu-plugins/search-analytics/includes/cli.php
@@ -96,18 +96,35 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 
 		$slugs = normalize_terms_with_ai( $gaps );
 
-		// During dry run, skip EP queries and just show term + count.
+		// Fetch candidate posts once; filter out terms with no matches (same as admin UI).
+		$candidates = [];
+		foreach ( $gaps as $gap ) {
+			$posts = get_posts_for_term( $gap['term'] );
+			if ( ! empty( $posts ) ) {
+				$candidates[ $gap['term'] ] = $posts;
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			\WP_CLI::success( 'No actionable suggestions — all qualifying terms either already exist as tags or matched no posts.' );
+			return;
+		}
+
 		if ( ! $apply ) {
 			$rows = [];
 			foreach ( $gaps as $gap ) {
 				$term = $gap['term'];
+				if ( ! isset( $candidates[ $term ] ) ) {
+					continue;
+				}
 				$rows[] = [
 					'term' => $term,
 					'count' => (int) $gap['count'],
 					'canonical' => $slugs[ $term ] ?? sanitize_title( $term ),
+					'candidate_posts' => count( $candidates[ $term ] ),
 				];
 			}
-			\WP_CLI\Utils\format_items( $format, $rows, [ 'term', 'count', 'canonical' ] );
+			\WP_CLI\Utils\format_items( $format, $rows, [ 'term', 'count', 'canonical', 'candidate_posts' ] );
 			\WP_CLI::log( '' );
 			\WP_CLI::log( 'Dry run. Pass --apply to create tags and apply them to matching posts.' );
 			return;
@@ -116,6 +133,9 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 		\WP_CLI::log( '' );
 		foreach ( $gaps as $gap ) {
 			$term = $gap['term'];
+			if ( ! isset( $candidates[ $term ] ) ) {
+				continue;
+			}
 			$slug = $slugs[ $term ] ?? sanitize_title( $term );
 
 			$result = wp_insert_term( $term, 'post_tag', [ 'slug' => $slug ] );
@@ -125,9 +145,8 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 			}
 
 			$tag_id = $result['term_id'];
-			$posts = get_posts_for_term( $term );
 			$applied = 0;
-			foreach ( $posts as $post ) {
+			foreach ( $candidates[ $term ] as $post ) {
 				wp_set_post_tags( $post['ID'], [ $tag_id ], true );
 				$applied++;
 			}

--- a/web/app/mu-plugins/search-analytics/includes/cli.php
+++ b/web/app/mu-plugins/search-analytics/includes/cli.php
@@ -48,9 +48,12 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 	 * default: 30
 	 * ---
 	 *
+	 * [--dry-run]
+	 * : Preview suggestions without creating or applying any tags. Default behaviour.
+	 *
 	 * [--apply]
 	 * : Create the suggested tags and apply them to EP-matched posts.
-	 *   Without this flag the command runs as a dry run.
+	 *   Omit this flag (or pass --dry-run) to preview only.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -70,8 +73,14 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 	public function __invoke( array $args, array $assoc_args ): void {
 		$min_count = (int) \WP_CLI\Utils\get_flag_value( $assoc_args, 'min-count', 5 );
 		$days = (int) \WP_CLI\Utils\get_flag_value( $assoc_args, 'days', 30 );
-		$apply = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'apply', false );
+		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$apply = \WP_CLI\Utils\get_flag_value( $assoc_args, 'apply', false );
 		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+
+		// --dry-run and --apply are mutually exclusive; --dry-run takes precedence.
+		if ( $dry_run ) {
+			$apply = false;
+		}
 
 		$gaps = get_tag_gaps( $min_count, $days );
 
@@ -86,22 +95,19 @@ class Tag_Gaps_Command extends \WP_CLI_Command {
 		}
 
 		$slugs = normalize_terms_with_ai( $gaps );
-		$rows = [];
 
-		foreach ( $gaps as $gap ) {
-			$term = $gap['term'];
-			$posts = get_posts_for_term( $term );
-			$rows[] = [
-				'term' => $term,
-				'count' => (int) $gap['count'],
-				'canonical' => $slugs[ $term ] ?? sanitize_title( $term ),
-				'candidate_posts' => count( $posts ),
-			];
-		}
-
-		\WP_CLI\Utils\format_items( $format, $rows, [ 'term', 'count', 'canonical', 'candidate_posts' ] );
-
+		// During dry run, skip EP queries and just show term + count.
 		if ( ! $apply ) {
+			$rows = [];
+			foreach ( $gaps as $gap ) {
+				$term = $gap['term'];
+				$rows[] = [
+					'term' => $term,
+					'count' => (int) $gap['count'],
+					'canonical' => $slugs[ $term ] ?? sanitize_title( $term ),
+				];
+			}
+			\WP_CLI\Utils\format_items( $format, $rows, [ 'term', 'count', 'canonical' ] );
 			\WP_CLI::log( '' );
 			\WP_CLI::log( 'Dry run. Pass --apply to create tags and apply them to matching posts.' );
 			return;

--- a/web/app/mu-plugins/search-analytics/includes/cli.php
+++ b/web/app/mu-plugins/search-analytics/includes/cli.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * WP-CLI command for suggested tags from search analytics.
+ *
+ * @package CommunityCode\SearchAnalytics
+ */
+
+namespace CommunityCode\SearchAnalytics\CLI;
+
+use function CommunityCode\SearchAnalytics\get_tag_gaps;
+use function CommunityCode\SearchAnalytics\get_posts_for_term;
+use function CommunityCode\SearchAnalytics\normalize_terms_with_ai;
+use function CommunityCode\SearchAnalytics\ai_is_available;
+
+/**
+ * Find and optionally act on frequently searched terms with no matching post_tag.
+ *
+ * ## EXAMPLES
+ *
+ *     # List suggested tags from the last 30 days with a minimum of 5 searches
+ *     wp cc-analytics tag-gaps
+ *
+ *     # Use a lower threshold and wider window
+ *     wp cc-analytics tag-gaps --min-count=2 --days=90
+ *
+ *     # Create the tags and apply them to matching posts (dry-run without --apply)
+ *     wp cc-analytics tag-gaps --apply
+ *
+ *     # Output as JSON
+ *     wp cc-analytics tag-gaps --format=json
+ */
+class Tag_Gaps_Command extends \WP_CLI_Command {
+
+	/**
+	 * List search terms that are frequently searched but have no matching post_tag.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--min-count=<n>]
+	 * : Minimum number of searches for a term to be included.
+	 * ---
+	 * default: 5
+	 * ---
+	 *
+	 * [--days=<n>]
+	 * : Look-back window in days. 0 = all time.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--apply]
+	 * : Create the suggested tags and apply them to EP-matched posts.
+	 *   Without this flag the command runs as a dry run.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$min_count = (int) \WP_CLI\Utils\get_flag_value( $assoc_args, 'min-count', 5 );
+		$days = (int) \WP_CLI\Utils\get_flag_value( $assoc_args, 'days', 30 );
+		$apply = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'apply', false );
+		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+
+		$gaps = get_tag_gaps( $min_count, $days );
+
+		if ( empty( $gaps ) ) {
+			\WP_CLI::success( 'No tag gaps found for the given criteria.' );
+			return;
+		}
+
+		$using_ai = ai_is_available();
+		if ( $using_ai ) {
+			\WP_CLI::log( 'AI plugin active — using AI-assisted term normalization.' );
+		}
+
+		$slugs = normalize_terms_with_ai( $gaps );
+		$rows = [];
+
+		foreach ( $gaps as $gap ) {
+			$term = $gap['term'];
+			$posts = get_posts_for_term( $term );
+			$rows[] = [
+				'term' => $term,
+				'count' => (int) $gap['count'],
+				'canonical' => $slugs[ $term ] ?? sanitize_title( $term ),
+				'candidate_posts' => count( $posts ),
+			];
+		}
+
+		\WP_CLI\Utils\format_items( $format, $rows, [ 'term', 'count', 'canonical', 'candidate_posts' ] );
+
+		if ( ! $apply ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'Dry run. Pass --apply to create tags and apply them to matching posts.' );
+			return;
+		}
+
+		\WP_CLI::log( '' );
+		foreach ( $gaps as $gap ) {
+			$term = $gap['term'];
+			$slug = $slugs[ $term ] ?? sanitize_title( $term );
+
+			$result = wp_insert_term( $term, 'post_tag', [ 'slug' => $slug ] );
+			if ( is_wp_error( $result ) ) {
+				\WP_CLI::warning( "Skipped \"{$term}\": " . $result->get_error_message() );
+				continue;
+			}
+
+			$tag_id = $result['term_id'];
+			$posts = get_posts_for_term( $term );
+			$applied = 0;
+			foreach ( $posts as $post ) {
+				wp_set_post_tags( $post['ID'], [ $tag_id ], true );
+				$applied++;
+			}
+
+			\WP_CLI::success( "Created tag \"{$term}\" (slug: {$slug}), applied to {$applied} post(s)." );
+		}
+	}
+}

--- a/web/app/mu-plugins/search-analytics/includes/suggestions.php
+++ b/web/app/mu-plugins/search-analytics/includes/suggestions.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Suggested tags: surface frequently searched terms with no matching post_tag.
+ *
+ * @package CommunityCode\SearchAnalytics
+ */
+
+namespace CommunityCode\SearchAnalytics;
+
+/**
+ * Return frequently searched terms that have no matching post_tag.
+ *
+ * Queries the analytics table for terms meeting the minimum search count, then
+ * filters out any that already exist as a post_tag (case-insensitive). These are
+ * candidates for new tags that reflect real visitor intent.
+ *
+ * @since 1.2.0
+ *
+ * @param int $min_count Minimum number of searches for a term to be included. Default 5.
+ * @param int $days      Look-back window in days. 0 = all time. Default 30.
+ * @return array[] Rows with keys: term (string), count (int). Sorted by count desc.
+ */
+function get_tag_gaps( int $min_count = 5, int $days = 30 ): array {
+	global $wpdb;
+	$table = get_table_name();
+
+	if ( $days > 0 ) {
+		$since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		$where_sql = $wpdb->prepare( 'WHERE searched_at >= %s', $since );
+	} else {
+		$where_sql = '';
+	}
+
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT term, COUNT(*) AS count FROM {$table} {$where_sql} GROUP BY term HAVING COUNT(*) >= %d ORDER BY count DESC",
+			$min_count
+		),
+		ARRAY_A
+	) ?: [];
+	// phpcs:enable
+
+	return array_values( array_filter( $rows, function ( array $row ): bool {
+		return ! get_term_by( 'name', $row['term'], 'post_tag' );
+	} ) );
+}
+
+/**
+ * Find published posts whose content matches a search term via ElasticPress.
+ *
+ * Uses ep_integrate=true so the search is powered by Elasticsearch. Returns an
+ * empty array if EP is not available or the query produces no results.
+ *
+ * @since 1.2.0
+ *
+ * @param string $term  The search term to match against.
+ * @param int    $limit Maximum number of posts to return. Default 10.
+ * @return array[] Rows with keys: ID (int), title (string), edit_url (string).
+ */
+function get_posts_for_term( string $term, int $limit = 10 ): array {
+	$query = new \WP_Query( [
+		's' => $term,
+		'ep_integrate' => true,
+		'posts_per_page' => $limit,
+		'post_type' => [ 'post', 'episodes' ],
+		'post_status' => 'publish',
+		'no_found_rows' => true,
+	] );
+
+	$results = [];
+	foreach ( $query->posts as $post ) {
+		$results[] = [
+			'ID' => $post->ID,
+			'title' => $post->post_title,
+			'edit_url' => get_edit_post_link( $post->ID, 'raw' ),
+		];
+	}
+	return $results;
+}
+
+/**
+ * Determine whether the WordPress AI plugin is installed and has valid credentials.
+ *
+ * @since 1.2.0
+ *
+ * @return bool
+ */
+function ai_is_available(): bool {
+	return function_exists( '\WordPress\AI\has_valid_ai_credentials' )
+		&& \WordPress\AI\has_valid_ai_credentials();
+}
+
+/**
+ * Suggest a canonical tag slug for each gap term, optionally using the AI plugin.
+ *
+ * Without AI: returns each term slugified via sanitize_title().
+ * With AI: sends the full term list to the AI plugin and asks it to group
+ * synonyms and suggest canonical slugs. Falls back to the non-AI path if the
+ * AI request fails or returns unparseable output.
+ *
+ * @since 1.2.0
+ *
+ * @param array[] $gaps Rows from get_tag_gaps() with keys: term, count.
+ * @return array<string, string> Map of raw term → suggested slug.
+ */
+function normalize_terms_with_ai( array $gaps ): array {
+	$fallback = [];
+	foreach ( $gaps as $row ) {
+		$fallback[ $row['term'] ] = sanitize_title( $row['term'] );
+	}
+
+	if ( ! ai_is_available() || empty( $gaps ) ) {
+		return $fallback;
+	}
+
+	$term_list = implode( ', ', array_column( $gaps, 'term' ) );
+	$prompt = sprintf(
+		'The following terms were searched on a podcast website about WordPress, open source, and tech communities. ' .
+		'For each term, suggest a canonical WordPress tag slug (lowercase, hyphenated). ' .
+		'Group obvious synonyms or variants under a single slug. ' .
+		'Return valid JSON only — an object mapping each raw term to its suggested slug. ' .
+		'Example: {"open source": "open-source", "OSS": "open-source"}. ' .
+		'Terms: %s',
+		$term_list
+	);
+
+	try {
+		$service = \WordPress\AI\get_ai_service();
+		$text = $service->create_textgen_prompt( $prompt, [
+			'temperature' => 0.2,
+			'max_tokens'  => 500,
+		] )->generate_text();
+
+		// Strip markdown code fences if the model wraps the JSON.
+		$text = preg_replace( '/^```(?:json)?\s*|\s*```$/s', '', trim( $text ) );
+		$decoded = json_decode( $text, true );
+
+		if ( ! is_array( $decoded ) ) {
+			return $fallback;
+		}
+
+		// Merge AI suggestions over the fallback so any missing terms get the slugified default.
+		foreach ( $decoded as $term => $slug ) {
+			$decoded[ $term ] = sanitize_title( $slug );
+		}
+		return array_merge( $fallback, $decoded );
+
+	} catch ( \Throwable $e ) {
+		return $fallback;
+	}
+}

--- a/web/app/mu-plugins/search-analytics/includes/suggestions.php
+++ b/web/app/mu-plugins/search-analytics/includes/suggestions.php
@@ -47,35 +47,46 @@ function get_tag_gaps( int $min_count = 5, int $days = 30 ): array {
 }
 
 /**
- * Find published posts whose content matches a search term via ElasticPress.
+ * Find published posts and episodes whose content matches a search term via ElasticPress.
  *
- * Uses ep_integrate=true so the search is powered by Elasticsearch. Returns an
- * empty array if EP is not available or the query produces no results.
+ * Runs separate queries for posts and episodes so both post types get their own
+ * relevance-ranked candidates regardless of which scores higher globally. This
+ * ensures that if a blog post is a candidate for a tag, the related episode is
+ * always considered too. Results are merged and deduplicated.
  *
  * @since 1.2.0
  *
  * @param string $term  The search term to match against.
- * @param int    $limit Maximum number of posts to return. Default 10.
+ * @param int    $limit Maximum results per post type. Default 5.
  * @return array[] Rows with keys: ID (int), title (string), edit_url (string).
  */
-function get_posts_for_term( string $term, int $limit = 10 ): array {
-	$query = new \WP_Query( [
+function get_posts_for_term( string $term, int $limit = 5 ): array {
+	$base_args = [
 		's' => $term,
 		'ep_integrate' => true,
 		'posts_per_page' => $limit,
-		'post_type' => [ 'post', 'episodes' ],
 		'post_status' => 'publish',
 		'no_found_rows' => true,
-	] );
+	];
 
+	$seen = [];
 	$results = [];
-	foreach ( $query->posts as $post ) {
-		$results[] = [
-			'ID' => $post->ID,
-			'title' => $post->post_title,
-			'edit_url' => get_edit_post_link( $post->ID, 'raw' ),
-		];
+
+	foreach ( [ 'post', 'episodes' ] as $type ) {
+		$query = new \WP_Query( array_merge( $base_args, [ 'post_type' => $type ] ) );
+		foreach ( $query->posts as $post ) {
+			if ( isset( $seen[ $post->ID ] ) ) {
+				continue;
+			}
+			$seen[ $post->ID ] = true;
+			$results[] = [
+				'ID' => $post->ID,
+				'title' => $post->post_title,
+				'edit_url' => get_edit_post_link( $post->ID, 'raw' ),
+			];
+		}
 	}
+
 	return $results;
 }
 

--- a/web/app/mu-plugins/search-analytics/search-analytics.php
+++ b/web/app/mu-plugins/search-analytics/search-analytics.php
@@ -18,7 +18,13 @@ define( 'CC_SEARCH_ANALYTICS_URL', str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, 
 require_once CC_SEARCH_ANALYTICS_DIR . 'includes/database.php';
 require_once CC_SEARCH_ANALYTICS_DIR . 'includes/data.php';
 require_once CC_SEARCH_ANALYTICS_DIR . 'includes/tracking.php';
+require_once CC_SEARCH_ANALYTICS_DIR . 'includes/suggestions.php';
 require_once CC_SEARCH_ANALYTICS_DIR . 'includes/admin.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once CC_SEARCH_ANALYTICS_DIR . 'includes/cli.php';
+	\WP_CLI::add_command( 'cc-analytics tag-gaps', 'CommunityCode\SearchAnalytics\CLI\Tag_Gaps_Command' );
+}
 
 // Database
 add_action( 'init', __NAMESPACE__ . '\\maybe_create_table' );
@@ -35,3 +41,4 @@ add_action( 'admin_init', __NAMESPACE__ . '\\handle_screen_options' );
 add_filter( 'set-screen-option', __NAMESPACE__ . '\\save_screen_option', 10, 3 );
 add_action( 'admin_menu', __NAMESPACE__ . '\\register_admin_page' );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_admin_assets' );
+add_action( 'wp_ajax_cc_create_analytics_tag', __NAMESPACE__ . '\\handle_create_analytics_tag' );


### PR DESCRIPTION
## Summary

Closes #68.

Surfaces frequently searched terms that have no matching `post_tag`, making it easy to close the gap between what visitors search for and what the site's taxonomy covers. Works at two levels — an admin dashboard section and a WP-CLI command — with optional AI-assisted slug normalization.

## What's new

### Admin: Suggested Tags section
A new section below Recent Searches shows terms searched above a threshold (default: 3) that have no matching tag, with:
- Search count and suggested slug (AI-assisted if the AI plugin is active, `sanitize_title()` fallback otherwise)
- Up to 5 candidate posts (found via EP search) with direct edit links
- One-click "Create tag" AJAX button per row

### WP-CLI: `wp cc-analytics tag-gaps`
```
wp cc-analytics tag-gaps [--min-count=<n>] [--days=<n>] [--apply] [--format=table|json|csv]
```
Dry-run by default. `--apply` creates the tags and applies them to EP-matched posts.

### AI integration
Gated on `WordPress\AI\has_valid_ai_credentials()`. When active, sends the term list to the AI plugin and asks it to group synonyms and suggest canonical slugs. Falls back to `sanitize_title()` silently when unavailable.

## Test plan
- [x] With no data meeting the threshold: section shows "No suggested tags" message
- [x] With qualifying terms: table renders with term, count, suggested slug, candidate posts, and Create tag button
- [x] Click "Create tag" → tag created, button state changes to "Created"
- [x] Check Tags screen → new tag exists with correct slug
- [x] `wp cc-analytics tag-gaps` — dry run output with table
- [x] `wp cc-analytics tag-gaps --apply` — creates tags and reports applied post count
- [x] With AI plugin active and configured: slugs reflect AI normalization
- [x] With AI plugin inactive: slugs fall back to `sanitize_title()`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)